### PR TITLE
fix: исправлен интерактивный ввод install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,19 @@
 - создаёт `telemt.toml`, `telemt-admin.toml`, `systemd` unit-файлы и Polkit-правило;
 - включает и запускает `telemt.service` и `telemt-admin.service`.
 
-Запуск:
+Запуск из интерактивного терминала:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/fgbm/telemt-admin/master/scripts/install.sh | sudo bash
+```
+
+Установщик задаёт интерактивные вопросы и читает ответы из терминала. Если TTY недоступен, скрипт завершится с ошибкой вместо бесконечных повторных prompt'ов.
+
+Для CI, automation или сессий без TTY сначала сохраните скрипт в файл и запустите его локально:
+
+```bash
+curl -fsSLo install.sh https://raw.githubusercontent.com/fgbm/telemt-admin/master/scripts/install.sh
+sudo bash ./install.sh
 ```
 
 Во время установки скрипт спросит только минимально необходимые значения:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -16,6 +16,8 @@ TELEMT_ADMIN_SERVICE_NAME="${TELEMT_ADMIN_SERVICE_NAME:-telemt-admin.service}"
 TELEMT_USER="${TELEMT_USER:-telemt}"
 TELEMT_ADMIN_USER="${TELEMT_ADMIN_USER:-telemt-admin}"
 POLKIT_RULE_PATH="${POLKIT_RULE_PATH:-/etc/polkit-1/rules.d/50-telemt-admin.rules}"
+PROMPT_INPUT_FD=0
+PROMPT_INPUT_SOURCE="stdin"
 
 if [ -t 1 ] && [ "${NO_COLOR:-}" = "" ] && [ "${TERM:-}" != "dumb" ]; then
     COLOR_BLUE='\033[1;34m'
@@ -130,6 +132,34 @@ ensure_systemd() {
     [ -d /run/systemd/system ] || fail "systemd не обнаружен. Этот установщик рассчитан на systemd-based Linux."
 }
 
+setup_prompt_input() {
+    if [ -t 0 ]; then
+        PROMPT_INPUT_FD=0
+        PROMPT_INPUT_SOURCE="stdin"
+        return 0
+    fi
+
+    if exec 3</dev/tty 2>/dev/null; then
+        PROMPT_INPUT_FD=3
+        PROMPT_INPUT_SOURCE="/dev/tty"
+        return 0
+    fi
+
+    fail "Интерактивный ввод недоступен. Запустите установщик из терминала с TTY. Для non-interactive среды сначала сохраните скрипт в файл и выполните его локально."
+}
+
+prompt_read_line() {
+    local __result_var="$1"
+    local prompt_text="$2"
+    local value
+
+    printf '%s' "$prompt_text" >&2
+    if ! IFS= read -r -u "$PROMPT_INPUT_FD" value; then
+        fail "Не удалось прочитать ввод из ${PROMPT_INPUT_SOURCE}. Установщик требует интерактивный терминал."
+    fi
+    printf -v "$__result_var" '%s' "$value"
+}
+
 validate_admin_ids() {
     local value="$1"
     printf '%s' "$value" | grep -Eq '^[0-9]+([[:space:]]*,[[:space:]]*[0-9]+)*$'
@@ -176,8 +206,7 @@ prompt_nonempty() {
     local prompt_text="$1"
     local value=""
     while [ -z "$value" ]; do
-        printf '%s: ' "$prompt_text" >&2
-        IFS= read -r value
+        prompt_read_line value "${prompt_text}: "
         if [ -z "$value" ]; then
             warn "Значение не может быть пустым."
         fi
@@ -188,8 +217,7 @@ prompt_nonempty() {
 prompt_admin_ids() {
     local value=""
     while true; do
-        printf '%s: ' "Telegram admin ID или список через запятую" >&2
-        IFS= read -r value
+        prompt_read_line value "Telegram admin ID или список через запятую: "
         if validate_admin_ids "$value"; then
             printf '%s' "$value"
             return 0
@@ -201,8 +229,7 @@ prompt_admin_ids() {
 prompt_port() {
     local value=""
     while true; do
-        printf '%s [443]: ' "Порт для telemt" >&2
-        IFS= read -r value
+        prompt_read_line value "Порт для telemt [443]: "
         value="${value:-443}"
         if ! validate_port "$value"; then
             warn "Введите корректный TCP-порт в диапазоне 1..65535."
@@ -224,8 +251,7 @@ prompt_tls_domain() {
 prompt_announce() {
     local value=""
     while true; do
-        printf '%s: ' "Публичный IPv4 для announce" >&2
-        IFS= read -r value
+        prompt_read_line value "Публичный IPv4 для announce: "
         if validate_ipv4 "$value"; then
             printf '%s' "$value"
             return 0
@@ -312,6 +338,7 @@ main() {
 
     info "Установка telemt + telemt-admin (Linux/systemd MVP)"
     info "Бинарники будут установлены в ${TELEMT_BIN_DIR%/}/telemt и ${TELEMT_ADMIN_BIN_DIR%/}/telemt-admin"
+    setup_prompt_input
 
     local bot_token
     local admin_ids_csv


### PR DESCRIPTION
## Summary
- переведён интерактивный ввод `scripts/install.sh` на единый helper с чтением из `/dev/tty`, чтобы запуск через pipe не зацикливался на пустом вводе
- добавлена явная ошибка для сценариев без интерактивного терминала вместо бесконечных повторных prompt'ов
- `README.md` обновлён: сохранён quick start через pipe и добавлен безопасный локальный сценарий запуска для окружений без TTY

Refs #14

## Test plan
- [x] `bash -n scripts/install.sh`
- [ ] Проверить на Debian 12 запуск `curl -fsSL ... | sudo bash`
- [ ] Проверить локальный запуск `sudo bash ./install.sh`
- [ ] Проверить негативный сценарий без TTY